### PR TITLE
Improve type related syntax issues

### DIFF
--- a/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
+++ b/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
@@ -52,7 +52,7 @@
           }
         },
         {
-          "begin": "--",
+          "begin": "--//",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.sql"

--- a/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
+++ b/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
@@ -52,7 +52,17 @@
           }
         },
         {
-          "begin": "--//",
+          "begin": "--",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.sql"
+            }
+          },
+          "end": "(?=$)",
+          "name": "comment.line.sql"
+        },
+        {
+          "begin": "//",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.sql"

--- a/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
+++ b/packages/langium-sql-vscode/syntaxes/sql.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.sql",
-      "match": "\\b([aA][lL][lL]|[aA][nN][dD]|[aA][sS]|[aA][sS][cC]|[bB][eE][tT][wW][eE][eE][nN]|[bB][lL][oO][bB]|[bB][oO][oO][lL][eE][aA][nN]|[bB][yY]|[cC][aA][sS][cC][aA][dD][eE]|[cC][aA][sS][tT]|[cC][aA][tT][aA][lL][oO][gG]|[cC][hH][aA][rR]|[cC][oO][nN][sS][tT][rR][aA][iI][nN][tT]|[cC][rR][eE][aA][tT][eE]|[cC][uU][rR][rR][eE][nN][tT]|[dD][aA][tT][aA][bB][aA][sS][eE]|[dD][aA][tT][eE][tT][iI][mM][eE]|[dD][eE][lL][eE][tT][eE]|[dD][eE][sS][cC]|[dD][iI][sS][tT][iI][nN][cC][tT]|[eE][nN][uU][mM]|[eE][xX][cC][eE][pP][tT]|[fF][aA][lL][sS][eE]|[fF][eE][tT][cC][hH]|[fF][iI][rR][sS][tT]|[fF][oO][lL][lL][oO][wW][iI][nN][gG]|[fF][oO][rR][eE][iI][gG][nN]|[fF][rR][oO][mM]|[fF][uU][nN][cC][tT][iI][oO][nN]|[gG][rR][oO][uU][pP]|[hH][aA][vV][iI][nN][gG]|[iI][nN]|[iI][nN][dD][eE][xX]|[iI][nN][tT]|[iI][nN][tT][eE][gG][eE][rR]|[iI][nN][tT][eE][rR][sS][eE][cC][tT]|[iI][sS]|[jJ][oO][iI][nN]|[kK][eE][yY]|[lL][eE][fF][tT]|[lL][iI][kK][eE]|[lL][iI][mM][iI][tT]|[mM][iI][nN][uU][sS]|[nN][eE][xX][tT]|[nN][oO][tT]|[nN][uU][lL][lL]|[oO][fF][fF][sS][eE][tT]|[oO][nN]|[oO][nN][lL][yY]|[oO][rR]|[oO][rR][dD][eE][rR]|[oO][vV][eE][rR]|[pP][aA][rR][tT][iI][tT][iI][oO][nN]|[pP][eE][rR][cC][eE][nN][tT]|[pP][rR][eE][cC][eE][dD][iI][nN][gG]|[pP][rR][iI][mM][aA][rR][yY]|[rR][aA][nN][gG][eE]|[rR][eE][aA][lL]|[rR][eE][cC][uU][rR][sS][iI][vV][eE]|[rR][eE][fF][eE][rR][eE][nN][cC][eE][sS]|[rR][iI][gG][hH][tT]|[rR][oO][wW]|[rR][oO][wW][sS]|[sS][cC][hH][eE][mM][aA]|[sS][eE][lL][eE][cC][tT]|[tT][aA][bB][lL][eE]|[tT][iI][eE][sS]|[tT][oO][pP]|[tT][rR][uU][eE]|[uU][nN][bB][oO][uU][nN][dD][eE][dD]|[uU][nN][iI][oO][nN]|[uU][nN][iI][qQ][uU][eE]|[uU][sS][iI][nN][gG]|[wW][hH][eE][rR][eE]|[wW][iI][tT][hH])\\b"
+      "match": "\\b([aA][lL][lL]|[aA][nN][dD]|[aA][sS]|[aA][sS][cC]|[bB][eE][tT][wW][eE][eE][nN]|[bB][yY]|[cC][aA][sS][cC][aA][dD][eE]|[cC][aA][sS][tT]|[cC][aA][tT][aA][lL][oO][gG]|[cC][oO][nN][sS][tT][rR][aA][iI][nN][tT]|[cC][rR][eE][aA][tT][eE]|[cC][uU][rR][rR][eE][nN][tT]|[dD][aA][tT][aA][bB][aA][sS][eE]|[dD][eE][lL][eE][tT][eE]|[dD][eE][sS][cC]|[dD][iI][sS][tT][iI][nN][cC][tT]|[eE][xX][cC][eE][pP][tT]|[fF][aA][lL][sS][eE]|[fF][eE][tT][cC][hH]|[fF][iI][rR][sS][tT]|[fF][oO][lL][lL][oO][wW][iI][nN][gG]|[fF][oO][rR][eE][iI][gG][nN]|[fF][rR][oO][mM]|[fF][uU][nN][cC][tT][iI][oO][nN]|[gG][rR][oO][uU][pP]|[hH][aA][vV][iI][nN][gG]|[iI][nN]|[iI][nN][dD][eE][xX]|[iI][nN][tT][eE][rR][sS][eE][cC][tT]|[iI][sS]|[jJ][oO][iI][nN]|[kK][eE][yY]|[lL][eE][fF][tT]|[lL][iI][kK][eE]|[lL][iI][mM][iI][tT]|[mM][iI][nN][uU][sS]|[nN][eE][xX][tT]|[nN][oO][tT]|[nN][uU][lL][lL]|[oO][fF][fF][sS][eE][tT]|[oO][nN]|[oO][nN][lL][yY]|[oO][rR]|[oO][rR][dD][eE][rR]|[oO][vV][eE][rR]|[pP][aA][rR][tT][iI][tT][iI][oO][nN]|[pP][eE][rR][cC][eE][nN][tT]|[pP][rR][eE][cC][eE][dD][iI][nN][gG]|[pP][rR][iI][mM][aA][rR][yY]|[rR][aA][nN][gG][eE]|[rR][eE][cC][uU][rR][sS][iI][vV][eE]|[rR][eE][fF][eE][rR][eE][nN][cC][eE][sS]|[rR][eE][pP][lL][aA][cC][eE]|[rR][iI][gG][hH][tT]|[rR][oO][wW]|[rR][oO][wW][sS]|[sS][cC][hH][eE][mM][aA]|[sS][eE][lL][eE][cC][tT]|[tT][aA][bB][lL][eE]|[tT][iI][eE][sS]|[tT][oO][pP]|[tT][rR][uU][eE]|[uU][nN][bB][oO][uU][nN][dD][eE][dD]|[uU][nN][iI][oO][nN]|[uU][nN][iI][qQ][uU][eE]|[uU][sS][iI][nN][gG]|[wW][hH][eE][rR][eE]|[wW][iI][tT][hH])\\b"
     },
     {
       "name": "string.quoted.double.sql",
@@ -52,7 +52,7 @@
           }
         },
         {
-          "begin": "--//",
+          "begin": "--",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.sql"

--- a/packages/langium-sql/src/sql-module.ts
+++ b/packages/langium-sql/src/sql-module.ts
@@ -22,6 +22,7 @@ import { SqlContainerManager } from "./sql-container-manager";
 import { SqlNameProvider } from "./sql-name-provider";
 import { SqlScopeComputation } from "./sql-scope-computation";
 import { SqlScopeProvider } from "./sql-scope-provider";
+import { SqlSemanticTokenProvider } from "./sql-semantic-token-provider";
 import { SqlValidationRegistry, SqlValidator } from "./sql-validator";
 import { SqlValueConverter } from "./sql-value-converter";
 import { SqlWorkspaceManager } from "./sql-workspace-manager";
@@ -77,6 +78,9 @@ export const SqlModule: Module<
         NameProvider: () => new SqlNameProvider(),
         ScopeComputation: (services) => new SqlScopeComputation(services),
         ScopeProvider: (services) => new SqlScopeProvider(services),
+    },
+    lsp: {
+        SemanticTokenProvider: (services) => new SqlSemanticTokenProvider(services),
     },
     validation: {
         ValidationRegistry: (services) => new SqlValidationRegistry(services),

--- a/packages/langium-sql/src/sql-semantic-token-provider.ts
+++ b/packages/langium-sql/src/sql-semantic-token-provider.ts
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * Copyright 2022-2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import {
+    AbstractSemanticTokenProvider,
+    AstNode,
+    SemanticTokenAcceptor
+} from "langium";
+import * as ast from "./generated/ast";
+import { SemanticTokenTypes } from 'vscode-languageserver';
+
+export class SqlSemanticTokenProvider extends AbstractSemanticTokenProvider {
+
+    protected highlightElement(node: AstNode, acceptor: SemanticTokenAcceptor): void {
+        if (ast.isDataType(node)) {
+            acceptor({
+                node,
+                property: 'dataTypeNames',
+                type: SemanticTokenTypes.type
+            });
+        } else if(ast.isStringLiteral(node)) {
+            acceptor({
+                node,
+                property: 'value',
+                type: SemanticTokenTypes.string
+            });
+        } else if(ast.isNumberLiteral(node)) {
+            acceptor({
+                node,
+                property: 'value',
+                type: SemanticTokenTypes.number
+            });
+        }
+    }
+}

--- a/packages/langium-sql/src/sql-type-computation.ts
+++ b/packages/langium-sql/src/sql-type-computation.ts
@@ -7,16 +7,12 @@ import { assertUnreachable, AstNode } from "langium";
 import _ from "lodash";
 import {
     Expression,
-    isBooleanType,
     isCastExpression,
     isExpression,
-    isIntegerType,
-    isRealType,
     Type,
     isTableRelatedColumnExpression,
     isBinaryExpression,
     isUnaryExpression,
-    isCharType,
     isNumberLiteral,
     isStringLiteral,
     isBooleanLiteral,
@@ -28,8 +24,6 @@ import {
     isType,
     isColumnDefinition,
     isColumnNameExpression,
-    isEnumType,
-    isDateTimeType,
     isCteColumnName,
     isFunctionDefinition,
     isNegatableExpression,
@@ -39,13 +33,13 @@ import {
     isParenthesisOrListExpression,
     NegatableExpression,
     SelectTableExpression,
-    isBlobType,
     isIdentifierAsStringLiteral,
 } from "./generated/ast";
 import { canConvert } from "./sql-type-conversion";
 import { areTypesEqual, RowTypeDescriptor, TypeDescriptor, Types } from "./sql-type-descriptors";
 import { BinaryOperator, BinaryOperators, UnaryOperator, UnaryOperators } from "./sql-type-operators";
 import {
+    DataTypes,
     getColumnsForSelectTableExpression, getFromGlobalReference,
 } from "./sql-type-utilities";
 
@@ -169,28 +163,28 @@ export function computeTypeOfSelectStatement(selectStatement: SelectTableExpress
 }
 
 export function computeTypeOfDataType(dataType: Type): TypeDescriptor | undefined {
-    if (isBooleanType(dataType)) {
+    if (DataTypes.isBooleanDataType(dataType)) {
         return Types.Boolean;
     }
-    if (isIntegerType(dataType)) {
+    if (DataTypes.isIntegerDataType(dataType)) {
         return Types.Integer;
     }
-    if (isRealType(dataType)) {
+    if (DataTypes.isRealDataType(dataType)) {
         return Types.Real;
     }
-    if (isCharType(dataType)) {
-        return Types.Char(dataType.length?.value);
+    if (DataTypes.isStringDataType(dataType)) {
+        return Types.Char();
     }
-    if(isEnumType(dataType)) {
-        return Types.Enum(dataType.members);
+    if (DataTypes.isEnumDataType(dataType)) {
+        return Types.Enum(dataType.arguments.map(e => e.value));
     }
-    if(isDateTimeType(dataType)) {
+    if (DataTypes.isDateTimeDataType(dataType)) {
         return Types.DateTime;
     }
-    if(isBlobType(dataType)) {
+    if (DataTypes.isBlobDataType(dataType)) {
         return Types.Blob;
     }
-    assertUnreachable(dataType);
+    return Types.Unknown;
 }
 
 const NumericLiteralPattern = /^(\d+)((\.(\d)+)?([eE]([\-+]?\d+))?)?$/;

--- a/packages/langium-sql/src/sql-type-descriptors.ts
+++ b/packages/langium-sql/src/sql-type-descriptors.ts
@@ -21,6 +21,7 @@ export type TypeDescriptorDiscriminator =
     | 'null'
     | 'array'
     | 'blob'
+    | 'unknown'
     ;
 
 export function isTypeANull(
@@ -89,6 +90,7 @@ export function isTypeAText(
 
 export interface TypeDescriptorBase {
     discriminator: TypeDescriptorDiscriminator;
+    arguments?: TypeArgument[];
 }
 
 export interface RowTypeDescriptor extends TypeDescriptorBase {
@@ -140,11 +142,21 @@ export interface BlobTypeDescriptor extends TypeDescriptorBase {
     discriminator: "blob";
 }
 
+export interface UnknownTypeDescriptor extends TypeDescriptorBase {
+    discriminator: "unknown";
+}
+
+export type TypeArgument = string | number;
 export type TextualTypeDescriptor = CharTypeDescriptor;
 export type NumberTypeDescriptor = IntegerTypeDescriptor|RealTypeDescriptor;
-export type TypeDescriptor = BlobTypeDescriptor | ArrayTypeDescriptor | NullTypeDescriptor | BooleanTypeDesciptor | NumberTypeDescriptor | TextualTypeDescriptor | RowTypeDescriptor | EnumTypeDescriptor | DateTimeTypeDescriptor;
+export type TypeDescriptor = UnknownTypeDescriptor | BlobTypeDescriptor | ArrayTypeDescriptor | NullTypeDescriptor | BooleanTypeDesciptor | NumberTypeDescriptor | TextualTypeDescriptor | RowTypeDescriptor | EnumTypeDescriptor | DateTimeTypeDescriptor;
+
+export type TypeSet = Record<string, TypeDescriptor | ((args: TypeArgument[]) => TypeDescriptor)>;
 
 export const Types = {
+    Unknown: {
+        discriminator: 'unknown'
+    } as UnknownTypeDescriptor,
     Null: {
         discriminator: 'null',
     } as NullTypeDescriptor,
@@ -175,8 +187,8 @@ export const Types = {
             length
         };
     },
-    Enum(members: string[]): TypeDescriptor {
-        return {discriminator: 'enum', members};
+    Enum(members: TypeArgument[]): TypeDescriptor {
+        return {discriminator: 'enum', members: members.filter(e => typeof e === 'string') as string[]};
     }
 }
 

--- a/packages/langium-sql/src/sql-type-utilities.ts
+++ b/packages/langium-sql/src/sql-type-utilities.ts
@@ -229,3 +229,216 @@ function getColumnsForTableSource(source: AST.TableSource): ColumnDescriptor[] {
         }
     });
 }
+
+export type Databases = "SQL" | "Oracle" | "MySQL" | "PostgreSQL" | "SQLServer" | "Presto";
+
+export namespace DataTypes {
+
+    type DataTypeList = Record<Databases, string[]>;
+
+    function getName(dataType: string): string {
+        const index = dataType.indexOf('(');
+        if (index >= 0) {
+            return dataType.substring(0, index).toUpperCase();
+        } else {
+            return dataType.toUpperCase();
+        }
+    }
+
+    function distinct<T>(arr: T[]): T[] {
+        return Array.from(new Set(arr));
+    }
+
+    export function isStringDataType(dataType: AST.DataType): boolean {
+        return isDataType(dataType, allStrings);
+    }
+
+    export function isIntegerDataType(dataType: AST.DataType): boolean {
+        return isDataType(dataType, allIntegers);
+    }
+
+    export function isRealDataType(dataType: AST.DataType): boolean {
+        return isDataType(dataType, allReals);
+    }
+
+    export function isDateTimeDataType(dataType: AST.DataType): boolean {
+        return isDataType(dataType, allDateTimes);
+    }
+
+    export function isBooleanDataType(dataType: AST.DataType): boolean {
+        return isDataType(dataType, allBooleans);
+    }
+
+    export function isBlobDataType(dataType: AST.DataType): boolean {
+        return isDataType(dataType, allBlobs);
+    }
+    
+    export function isEnumDataType(dataType: AST.DataType): boolean {
+        return isDataType(dataType, ['ENUM']);
+    }
+
+    function isDataType(dataType: AST.DataType, values: string[]): boolean {
+        const name = dataType.dataTypeNames.join(' ').toUpperCase();
+        return values.includes(name);
+    }
+
+    export const STRINGS: DataTypeList = {
+        SQL: [
+            'TEXT'
+        ],
+        MySQL: [
+            'CHAR(size?)',
+            'VARCHAR(size)',
+            'TINYTEXT',
+            'TEXT(size)',
+            'MEDIUMTEXT',
+            'LONGTEXT'
+        ],
+        Oracle: [
+            'VARCHAR2(size)',
+            'NVARCHAR2(size)',
+            'NCHAR(size)',
+            'CLOB',
+            'NCLOB',
+        ],
+        PostgreSQL: [
+            'CHARACTER VARYING(size)',
+            'VARCHAR(size)',
+            'CHARACTER(n)',
+            'CHAR(n)',
+            'TEXT'
+        ],
+        Presto: [
+            'CHAR',
+            'VARCHAR'
+        ],
+        SQLServer: [
+            'CHAR(size)',
+            'VARCHAR(size)',
+            'TEXT',
+            'NCHAR',
+            'NVARCHAR',
+            'NTEXT'
+        ]
+    };
+
+    export const INTEGERS: DataTypeList = {
+        SQL: [
+            'INT',
+            'INTEGER'
+        ],
+        MySQL: [
+            'BIT(size)',
+            'TINYINT(size)',
+            'SMALLINT(size)',
+            'MEDIUMINT(size)',
+            'INT(size)',
+            'INTEGER(size)',
+            'BIGINT(size)'
+        ],
+        Oracle: [],
+        SQLServer: [
+            'BIT',
+            'TINYINT',
+            'SMALLINT',
+            'INT',
+            'BIGINT'
+        ],
+        PostgreSQL: [],
+        Presto: []
+    };
+
+    export const REALS: DataTypeList = {
+        SQL: ['REAL'],
+        Oracle: [
+            'NUMBER(p?, s?)',
+            'BINARY_FLOAT',
+            'BINARY_DOUBLE'
+        ],
+        MySQL: [],
+        PostgreSQL: [],
+        Presto: [],
+        SQLServer: [
+            'REAL',
+            'FLOAT(n?)',
+            'DECIMAL(p?, s?)',
+            'NUMERIC(p?, s?)',
+            'SMALLMONEY',
+            'MONEY'
+        ]
+    };
+
+    export const BOOLEANS: DataTypeList = {
+        SQL: ['BOOLEAN', 'BOOL'],
+        MySQL: [],
+        Oracle: [],
+        PostgreSQL: [],
+        Presto: [],
+        SQLServer: []
+    };
+
+    export const BLOBS: DataTypeList = {
+        SQL: ['BLOB'],
+        MySQL: [
+            'BINARY(size)',
+            'VARBINARY(size)',
+            'TINYBLOB',
+            'BLOB(size)',
+            'MEDIUMBLOB',
+            'LONGBLOB'
+        ],
+        Oracle: [
+            'RAW(size)',
+            'LONG RAW',
+            'BLOB',
+            'BFILE'
+        ],
+        PostgreSQL: [],
+        Presto: [],
+        SQLServer: [
+            'BINARY(n)',
+            'VARBINARY',
+            'IMAGE'
+        ]
+    };
+
+    export const DATETIMES: DataTypeList = {
+        SQL: ['DATETIME'],
+        MySQL: [
+            'DATE',
+            'DATETIME(fsp?)',
+            'TIMESTAMP(fsp?)',
+            'TIME(fsp?)',
+            'YEAR'
+        ],
+        SQLServer: [
+            'DATETIME',
+            'DATETIME2',
+            'SMALLDATETIME',
+            'DATE',
+            'TIME',
+            'DATETIMEOFFSET',
+            'TIMESTAMP'
+        ],
+        Oracle: [
+            'TIMESTAMP(fsp?)',
+            'TIMESTAMP(fsp?) WITH TIME ZONE',
+            'TIMESTAMP(fsp?) WITH LOCAL TIME ZONE',
+            'INTERVAL YEAR(p?) TO MONTH',
+            'INTERVAL DAY(p?) TO SECOND'
+        ],
+        PostgreSQL: [],
+        Presto: []
+    };
+
+    const allStrings = all(STRINGS);
+    const allIntegers = all(INTEGERS);
+    const allReals = all(REALS);
+    const allDateTimes = all(DATETIMES);
+    const allBlobs = all(BLOBS);
+    const allBooleans = all(BOOLEANS);
+
+    function all(list: DataTypeList): string[] {
+        return distinct(Object.values(list).flat().map(getName));
+    }
+} 

--- a/packages/langium-sql/src/sql-type-utilities.ts
+++ b/packages/langium-sql/src/sql-type-utilities.ts
@@ -355,7 +355,9 @@ export namespace DataTypes {
             'BINARY_FLOAT',
             'BINARY_DOUBLE'
         ],
-        MySQL: [],
+        MySQL: [
+            'DECIMAL(p?, s?)'
+        ],
         PostgreSQL: [],
         Presto: [],
         SQLServer: [

--- a/packages/langium-sql/src/sql-validator.ts
+++ b/packages/langium-sql/src/sql-validator.ts
@@ -3,7 +3,6 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
-
 import {
     ValidationAcceptor,
     ValidationChecks,

--- a/packages/langium-sql/src/sql.langium
+++ b/packages/langium-sql/src/sql.langium
@@ -337,4 +337,5 @@ terminal ID: /[_a-zA-Z][\w_]*/;
 terminal NUMBER returns number: /\d+((\.\d+)?([eE][\-+]?\d+)?)?/;
 
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
-hidden terminal SL_COMMENT: /(\-\-|\/\/)[^\n\r]*/;
+hidden terminal TICK_COMMENT: /\-\-[^\n\r]*/;
+hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/packages/langium-sql/src/sql.langium
+++ b/packages/langium-sql/src/sql.langium
@@ -5,7 +5,7 @@ entry SqlFile:
 ;
 
 Statement:
-    (DefinitionRule | RootLevelSelectStatement) ';';
+    (DefinitionRule | RootLevelSelectStatement) ';'?;
 
 DefinitionRule:
     CatalogDefinition | SchemaDefinition | TableDefinition | FunctionDefinition;
@@ -51,7 +51,7 @@ TableContentDefinition:
 ;
 
 ColumnDefinition:
-    name=Identifier dataType=Type (negated?='NOT' null?='NULL')?;
+    name=Identifier dataType=Type (negated?='NOT'? null?='NULL')?;
 
 PrimaryKeyDefinition:
     'PRIMARY' 'KEY' '(' primaryKeys+=[ColumnDefinition] (',' primaryKeys+=[ColumnDefinition])* ')'

--- a/packages/langium-sql/src/sql.langium
+++ b/packages/langium-sql/src/sql.langium
@@ -128,17 +128,20 @@ SimpleSelectStatement:
 /**
  * SQL Server `FETCH FIRST` syntax
  */
-TopClause: 'TOP' value=NUMBER percent?='PERCENT';
+TopClause:
+    'TOP' value=NUMBER percent?='PERCENT';
 
 /**
  * MySQL/PostreSQL `FETCH FIRST` syntax
  */
-LimitClause: 'LIMIT' (offset=NUMBER ',' limit=NUMBER | limit=NUMBER ('OFFSET' offset=NUMBER)?);
+LimitClause:
+    'LIMIT' (offset=NUMBER ',' limit=NUMBER | limit=NUMBER ('OFFSET' offset=NUMBER)?);
 
 /**
  * Oracle/Standard `FETCH FIRST` syntax
  */
-FetchFirstClause: ('OFFSET' offset=NUMBER offsetRows?='ROWS'?)? 'FETCH' (first?='FIRST' | 'NEXT') limit=NUMBER 'ROWS' (only?='ONLY' | 'WITH' 'TIES');
+FetchFirstClause:
+    ('OFFSET' offset=NUMBER offsetRows?='ROWS'?)? 'FETCH' (first?='FIRST' | 'NEXT') limit=NUMBER 'ROWS' (only?='ONLY' | 'WITH' 'TIES');
 
 WithClause:
     'WITH' 'RECURSIVE'? ctes+=CommonTableExpression (',' ctes+=CommonTableExpression)*;
@@ -243,11 +246,11 @@ MultiplicativeExpression infers Expression:
 //Syntax for SingleStore SQL (https://docs.singlestore.com/managed-service/en/reference/sql-reference/json-functions/json_extract_-type-.html)
 JsonExtractExpression infers Expression:
     PrimaryExpression ({infer BinaryExpression.left=current} operator=('::$'|'::%'|'::') right=(StringLiteral|NumberLiteral|IdentifierAsStringLiteral))*
-    ;
+;
 
 IdentifierAsStringLiteral infers Expression:
     {infer IdentifierAsStringLiteral}value=Identifier
-    ;
+;
 
 PrimaryExpression infers Expression:
     {infer StringLiteral} StringLiteral
@@ -315,20 +318,14 @@ NumberLiteral:
 StringLiteral:
     value=STRING;
 BooleanLiteral:
-    value=('TRUE'|'FALSE');
+    value?='TRUE' | 'FALSE';
 HexStringLiteral:
     value=HEX_STRING;
 
-Type infers Type:
-    {infer BooleanType} 'BOOLEAN'
-    | {infer IntegerType} ('INTEGER'|'INT')
-    | {infer RealType} 'REAL'
-    | {infer CharType} 'CHAR' ('(' length=NumberLiteral ')')?
-    | {infer EnumType} 'ENUM' '(' members+=STRING (',' members+=STRING)* ')'
-    | {infer DateTimeType} 'DATETIME'
-    | {infer BlobType} 'BLOB'
-    ;
+Type: type=ID ('(' arguments+=TypeArgument (',' arguments+=TypeArgument)? ')')?;
 
+TypeArgument:
+    NumberLiteral | StringLiteral;
 
 hidden terminal WS: /\s+/;
 terminal HEX_STRING returns string: /x\'[A-Fa-f0-9]+\'/;

--- a/packages/langium-sql/src/sql.langium
+++ b/packages/langium-sql/src/sql.langium
@@ -129,7 +129,7 @@ SimpleSelectStatement:
  * SQL Server `FETCH FIRST` syntax
  */
 TopClause:
-    'TOP' value=NUMBER percent?='PERCENT';
+    'TOP' value=NUMBER percent?='PERCENT'?;
 
 /**
  * MySQL/PostreSQL `FETCH FIRST` syntax

--- a/packages/langium-sql/src/sql.langium
+++ b/packages/langium-sql/src/sql.langium
@@ -71,7 +71,7 @@ ConstraintDefinition:
 ;
 
 FunctionDefinition:
-    'CREATE' 'FUNCTION' ReferenceNamed '('
+    'CREATE' ('OR' replace?='REPLACE')? 'FUNCTION' ReferenceNamed '('
         (params+=FormalParameterDefinition (',' params+=FormalParameterDefinition)*)?
     ')' 'AS' returnType=Type;
 
@@ -249,7 +249,7 @@ JsonExtractExpression infers Expression:
 ;
 
 IdentifierAsStringLiteral infers Expression:
-    {infer IdentifierAsStringLiteral}value=Identifier
+    {infer IdentifierAsStringLiteral} value=Identifier
 ;
 
 PrimaryExpression infers Expression:
@@ -307,7 +307,7 @@ CastExpression:
     'CAST' '(' expr=Expression 'AS' type=Type ')'
 ;
 
-type ColumnNameSource = ColumnDefinition|ExpressionQuery;
+type ColumnNameSource = ColumnDefinition | ExpressionQuery;
 
 Identifier returns string:
     ID | TICK_STRING
@@ -322,9 +322,11 @@ BooleanLiteral:
 HexStringLiteral:
     value=HEX_STRING;
 
-Type: type=ID ('(' arguments+=TypeArgument (',' arguments+=TypeArgument)? ')')?;
+Type: DataType;
 
-TypeArgument:
+DataType: dataTypeNames+=ID+ ('(' arguments+=DataTypeArgument (',' arguments+=DataTypeArgument)? ')')?;
+
+DataTypeArgument:
     NumberLiteral | StringLiteral;
 
 hidden terminal WS: /\s+/;

--- a/packages/langium-sql/test/syntax/create-table-syntax.test.ts
+++ b/packages/langium-sql/test/syntax/create-table-syntax.test.ts
@@ -1,0 +1,36 @@
+/******************************************************************************
+ * Copyright 2022-2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { LangiumDocument } from 'langium';
+import { NodeFileSystem } from 'langium/node';
+import {beforeAll, describe, expect, it} from 'vitest'
+import { SqlFile } from '../../src/generated/ast';
+import { createSqlServices } from '../../src/sql-module';
+import { expectNoErrors, parseHelper } from '../test-utils';
+
+const services = createSqlServices(NodeFileSystem);
+
+describe('CREATE TABLE syntax coverage', () => {
+    let parse: (input: string) => Promise<LangiumDocument<SqlFile>>;
+
+    beforeAll(async () => {
+        parse = await parseHelper(services.Sql);
+    });
+
+    async function expectParseable(content: string) {
+        const document = await parse(content);
+        expectNoErrors(document);
+        for (const reference of document.references) {
+            expect(reference.ref).not.toBe(undefined);
+        }
+        return document;
+    }
+
+    it('Simple CREATE TABLE', () => expectParseable('CREATE TABLE X(Y int);'));
+    it('Simple CREATE TABLE with multiple columns', () => expectParseable('CREATE TABLE X(Y int, Z real);'));
+    it('Simple CREATE TABLE with nullable column', () => expectParseable('CREATE TABLE X(Y int NULL);'));
+    it('Simple CREATE TABLE with non-nullable column', () => expectParseable('CREATE TABLE X(Y int NOT NULL);'));
+});

--- a/packages/langium-sql/test/syntax/select-syntax.test.ts
+++ b/packages/langium-sql/test/syntax/select-syntax.test.ts
@@ -3,6 +3,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
+
 import { LangiumDocument } from 'langium';
 import { NodeFileSystem } from 'langium/node';
 import { join } from 'path';
@@ -13,7 +14,7 @@ import { expectNoErrors, parseHelper } from '../test-utils';
 
 const services = createSqlServices(NodeFileSystem);
 
-describe('Syntax coverage', () => {
+describe('SELECT Syntax coverage', () => {
     let parse: (input: string) => Promise<LangiumDocument<SqlFile>>;
 
     beforeAll(async () => {
@@ -30,6 +31,10 @@ describe('Syntax coverage', () => {
     }
 
     it('Simple select', () => expectParseable('SELECT * FROM airline;'));
+    it('Statements without semicolon', () => expectParseable(`
+        SELECT * FROM airline
+        SELECT * FROM booking
+    `));
     it('Select with table variable', () => expectParseable('SELECT a.* FROM airline a;'));
     it('Join with using', () => expectParseable(`
         SELECT firstname, lastname, flightno

--- a/packages/langium-sql/test/test-utils.ts
+++ b/packages/langium-sql/test/test-utils.ts
@@ -21,22 +21,24 @@ import { isAllTable, SimpleSelectTableExpression } from "../src/generated/ast";
 import { getColumnsForSelectTableExpression } from "../src/sql-type-utilities";
 import path from "path";
 import { SqlNameProvider } from "../src/sql-name-provider";
+import { WorkspaceFolder } from 'vscode-languageserver';
 
 const nameProvider = new SqlNameProvider();
 
 export async function parseHelper(
     services: SqlServices,
-    folder: string
+    folder?: string
 ): Promise<(input: string) => Promise<LangiumDocument<ast.SqlFile>>> {
     const metaData = services.LanguageMetaData;
     const documentBuilder = services.shared.workspace.DocumentBuilder;
-    const uri = URI.file(path.resolve(folder)).toString();
-    await services.shared.workspace.WorkspaceManager.initializeWorkspace([
-        {
-            name: "main",
-            uri,
-        },
-    ]);
+    const workspaces: WorkspaceFolder[] = [];
+    if (folder) {
+        workspaces.push({
+            name: 'main',
+            uri: URI.file(path.resolve(folder)).toString()
+        })
+    }
+    await services.shared.workspace.WorkspaceManager.initializeWorkspace(workspaces);
     return async (input) => {
         const randomNumber = Math.floor(Math.random() * 10000000) + 1000000;
         const uri = URI.parse(


### PR DESCRIPTION
* Allow to use `NULL` in column definition (previously only `NOT NULL` was supported)
* Allow arbitrary data types that are not covered by the SQL spec (such as `VARCHAR` for strings or `DECIMAL` for numbers)